### PR TITLE
TravisCI integration. Use Docker, install ChefDK and Kitchen-Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+sudo: required
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 sudo: required
 dist: trusty
+
+# Don't `bundle install`
+install: echo "skip bundle install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ addons:
       - chef-stable-trusty
     packages:
       - chefdk
+
+script:
+  - /opt/chefdk/bin/kitchen --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 dist: trusty
 
+language: python
+
 # Use 'chef-stable-trusty' to install the stable release of the ChefDK
 addons:
   apt:
@@ -8,6 +10,3 @@ addons:
       - chef-stable-trusty
     packages:
       - chefdk
-
-# Don't `bundle install`
-install: echo "skip bundle install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 sudo: required
 dist: trusty
 
+# Use 'chef-stable-trusty' to install the stable release of the ChefDK
+addons:
+  apt:
+    sources:
+      - chef-stable-trusty
+    packages:
+      - chefdk
+
 # Don't `bundle install`
 install: echo "skip bundle install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,11 @@ addons:
     packages:
       - chefdk
 
+before_script:
+  # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888
+  - sudo iptables -L DOCKER || sudo iptables -N DOCKER
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  - /opt/chefdk/bin/chef gem install kitchen-docker
+
 script:
   - /opt/chefdk/bin/kitchen --version


### PR DESCRIPTION
- [X] TravisCI building Pull Requests and pushes.
- [X] Enable Docker.
- [X] Installing the stable version of ChefDK (contains KitchenCI).
- [X] Install 'kitchen-docker' in the ChefDK path.