### PR TITLE
Enable caching

### DIFF
--- a/roles/nginx-cdn/defaults/main.yml
+++ b/roles/nginx-cdn/defaults/main.yml
@@ -22,16 +22,21 @@ nginx_cdn_proxy_next_upstream:
   - invalid_header
   - http_500
   - updating
+
+# Need to have this in a single line to avoid the parser removing
+# the double quotes from the format.
+# TODO: Find a better list solution :)
+nginx_cdn_log_format: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $upstream_addr
 nginx_cdn_http_default_params:
+  - log_format main '{{ nginx_cdn_log_format }}'
   - sendfile "on"
   - tcp_nopush "on"
   - tcp_nodelay "on"
   - keepalive_timeout "65"
-  - access_log "{{nginx_log_dir}}/access.log"
+  - "access_log {{nginx_log_dir}}/access.log main"
   - "error_log {{nginx_log_dir}}/error.log {{nginx_error_log_level}}"
   - server_tokens off
   - types_hash_max_size 2048
-nginx_http_params: "{{ nginx_cdn_http_default_params }}"
 nginx_cdn_cache_path: /tmp/nginx-cache
 nginx_cdn_proxy_cache_path_options:
   - "{{nginx_cdn_cache_path}}"

--- a/roles/nginx-cdn/defaults/main.yml
+++ b/roles/nginx-cdn/defaults/main.yml
@@ -1,0 +1,41 @@
+---
+nginx_cdn_http_port: 80
+nginx_cdn_https_port: 443
+nginx_cdn_upstream_list:
+  - server us-pro-host01.ext.cabify.com:443;
+  - server us-pro-host02.ext.cabify.com:443;
+  - server us-pro-host03.ext.cabify.com:443;
+nginx_cdn_cache_file_formats:
+  - ico
+  - js
+  - css
+  - png
+  - gif
+  - jpe?g
+  - swf
+  - txt
+  - html?
+  - htc
+nginx_cdn_proxy_next_upstream:
+  - error
+  - timeout
+  - invalid_header
+  - http_500
+  - updating
+nginx_cdn_http_default_params:
+  - sendfile "on"
+  - tcp_nopush "on"
+  - tcp_nodelay "on"
+  - keepalive_timeout "65"
+  - access_log "{{nginx_log_dir}}/access.log"
+  - "error_log {{nginx_log_dir}}/error.log {{nginx_error_log_level}}"
+  - server_tokens off
+  - types_hash_max_size 2048
+nginx_http_params: "{{ nginx_cdn_http_default_params }}"
+nginx_cdn_cache_path: /tmp/nginx-cache
+nginx_cdn_proxy_cache_path_options:
+  - "{{nginx_cdn_cache_path}}"
+  - levels=1:2
+  - keys_zone=cache:10m
+  - inactive=30s
+  - use_temp_path=off

--- a/roles/nginx-cdn/defaults/main.yml
+++ b/roles/nginx-cdn/defaults/main.yml
@@ -26,7 +26,7 @@ nginx_cdn_proxy_next_upstream:
 # Need to have this in a single line to avoid the parser removing
 # the double quotes from the format.
 # TODO: Find a better list solution :)
-nginx_cdn_log_format: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $upstream_addr
+nginx_cdn_log_format: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $upstream_addr $upstream_cache_status
 nginx_cdn_http_default_params:
   - log_format main '{{ nginx_cdn_log_format }}'
   - sendfile "on"

--- a/roles/nginx-cdn/meta/main.yml
+++ b/roles/nginx-cdn/meta/main.yml
@@ -6,20 +6,33 @@ dependencies:
     nginx_configs:
       upstream:
         - upstream cabify {
-            server us-pro-host01.ext.cabify.com:443;
-            server us-pro-host02.ext.cabify.com:443;
-            server us-pro-host03.ext.cabify.com:443;
+            {{ nginx_cdn_upstream_list | join(" ")}}
           }
       ssl:
         - ssl_certificate_key {{ssl_certs_privkey_path}}
         - ssl_certificate     {{ssl_certs_cert_path}}
         - ssl_dhparam         {{ssl_certs_dhparam_path}}
+      cache:
+        - proxy_cache_path {{ nginx_cdn_proxy_cache_path_options | join(" ") }}
     nginx_sites:
       cabify-http:
-        - listen 80 default_server
+        - listen {{nginx_cdn_http_port}} default_server
         - return 301 https://$host$request_uri
       cabify-https:
-        - listen 443 ssl
+        - listen {{nginx_cdn_https_port}} ssl
+        - proxy_cache cache
+        - proxy_cache_revalidate on
+        - proxy_set_header X-Real-IP $remote_addr
+        - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+        - add_header X-Cache-Status $upstream_cache_status
+        - location ~* \.({{ nginx_cdn_cache_file_formats | join("|") }})$ {
+             proxy_next_upstream {{ nginx_cdn_proxy_next_upstream | join(" ") }};
+             proxy_set_header Host $host;
+             proxy_cache_valid 200 60m;
+             proxy_pass https://cabify;
+          }
         - location / {
+             proxy_next_upstream {{ nginx_cdn_proxy_next_upstream | join(" ") }};
+             proxy_set_header Host $host;
              proxy_pass https://cabify;
           }

--- a/roles/nginx-cdn/vars/main.yml
+++ b/roles/nginx-cdn/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# Need to define this as a var to have precedence over the default value
+nginx_http_params: "{{ nginx_cdn_http_default_params }}"

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -37,6 +37,7 @@ describe file('/etc/nginx/nginx.conf') do
 end
 
 [
+  'cache',
   'ssl',
   'upstream'
 ].each do |nginx_conf_file|


### PR DESCRIPTION
- [X] Cache static resources (js, css, ...).
- [X] Cache HEAD and GET responses (ie. GET /api/regions).
- [X] Add some fields to the default log_format to see the upstream server and the cache status.
- [X] Extract some hardcoded values into defaults.